### PR TITLE
中文文档

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -114,8 +114,8 @@ user_manual_zh:
   url: /config-vimrc/
 - text: 颜色主题配置
   url: /config-colorscheme/
-- text: Config Open File Action
-  url: /自定义文件打开方式/
+- text: 自定义文件打开方式
+  url: /config-open-file-action/
 - text: 插件
   url: /plugins/
 - text: 已知问题


### PR DESCRIPTION
更正了中文文档侧边栏中"自定义文本打开方式"一项，显示文本及其背后连接错误的问题。